### PR TITLE
음식점 목록에서 음식점 클릭 시 상세페이지 컴포넌트 호출이 안되는 문제 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,10 +18,7 @@ class App extends Component {
           <Route path="/all" component={StoreListPage} />
           <Route path="/franchise" component={StoreList} />
           <Route path="/chicken" component={StoreList} />
-          <Route
-            path="/restaurants/api/restaurant/?id=:id"
-            component={StoreDetailPage}
-          />
+          <Route path="/store/:id" component={StoreDetailPage} />
         </React.Fragment>
       </BrowserRouter>
     );

--- a/src/components/StoreDetailView.js
+++ b/src/components/StoreDetailView.js
@@ -22,10 +22,12 @@ export default class StoreDetailView extends Component {
       payment,
       estimatedDeliveryTime
     } = this.props;
-    console.log(name);
+    console.log(`gg`);
     return (
       <div className="StoreDetail__info-wrap">
         <h1 className="StoreDetail__name">{name}</h1>
+        {console.log(name)}
+        store
       </div>
     );
   }

--- a/src/components/StoreListView.js
+++ b/src/components/StoreListView.js
@@ -12,7 +12,9 @@ export default class StoreListView extends Component {
       <ul>
         {storeList.map(l => (
           <li className="StoreList__item" key={l.id}>
-            <Link to={`/restaurants/api/restaurant/?id=${l.id}`}>
+            <Link to={`/store/${l.id}`}>
+              {console.log(`/store/${l.id}`)}
+
               <img src={l.logoUrl} alt={l.name} className="StoreList__img" />
               <h1 className="StoreList__name">{l.name}</h1>
               <div className="StoreList__info-wrap">


### PR DESCRIPTION
음식점 목록에서 음식점 클릭 시 상세페이지 컴포넌트 호출이 안되는 문제 해결
상세 페이지에서 해당 음식점 정보 불러오기 진행해야 합니다.